### PR TITLE
Fix unescape values in queryMemberWithNameForGroup

### DIFF
--- a/open-secret-santa-app-it/pom.xml
+++ b/open-secret-santa-app-it/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.moac.android.opensecretsanta</groupId>
     <artifactId>open-secret-santa-app-parent</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
   </parent>
 
   <artifactId>open-secret-santa-app-it</artifactId>

--- a/open-secret-santa-app-it/src/main/java/com/moac/android/opensecretsanta/test/database/DatabaseTests.java
+++ b/open-secret-santa-app-it/src/main/java/com/moac/android/opensecretsanta/test/database/DatabaseTests.java
@@ -429,4 +429,38 @@ public class DatabaseTests extends AndroidTestCase {
         assertEquals(0, mDatabaseManager.queryAllRestrictionsForMemberId(m1.getId()).size());
     }
 
+    /**
+     * Test that names with inverted commas and quotes don't cause exceptions!
+     *
+     * android.database.SQLException: Problems executing Android query: SELECT * FROM `members` WHERE (`GROUP_ID` = 1 AND `NAME` = 'Father O'Leary' )
+     *
+     */
+    public void testQueryMemberNameWithApostrophesOk() {
+        Group group1 = new GroupBuilder().build();
+        mDatabaseManager.create(group1);
+
+        // Add a Member with an apostrophe in the name
+        Member m1 = new MemberBuilder().withName("Father O'Leary").build();
+        m1.setGroup(group1);
+        mDatabaseManager.create(m1);
+
+        // Previously the following query would throw an SQLException
+        Member m1Back = mDatabaseManager.queryMemberWithNameForGroup(group1.getId(), m1.getName());
+        assertEquals("Father O'Leary", m1Back.getName());
+    }
+
+    public void testQueryMemberNameWithQuotesOk() {
+        Group group1 = new GroupBuilder().build();
+        mDatabaseManager.create(group1);
+
+        // Add a Member with an inverted commas in the name
+        Member m1 = new MemberBuilder().withName("Father O\"Leary").build();
+        m1.setGroup(group1);
+        mDatabaseManager.create(m1);
+
+        // Previously the following query would throw an SQLException
+        Member m1Back = mDatabaseManager.queryMemberWithNameForGroup(group1.getId(), m1.getName());
+        assertEquals("Father O\"Leary", m1Back.getName());
+    }
+
 }

--- a/open-secret-santa-app/AndroidManifest.xml
+++ b/open-secret-santa-app/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   android:installLocation="preferExternal"
-  android:versionCode="6"
-  android:versionName="1.4.1"
+  android:versionCode="7"
+  android:versionName="1.4.2"
   package="com.moac.android.opensecretsanta">
 
   <uses-permission android:name="android.permission.READ_CONTACTS" />

--- a/open-secret-santa-app/changelist.txt
+++ b/open-secret-santa-app/changelist.txt
@@ -1,3 +1,6 @@
+Version - 1.4.2
+---------------
+Fix to allow querying of Member names that contain apostrophes.
 
 Version - 1.3.1
 ---------------

--- a/open-secret-santa-app/pom.xml
+++ b/open-secret-santa-app/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.moac.android.opensecretsanta</groupId>
     <artifactId>open-secret-santa-app-parent</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
   </parent>
 
   <artifactId>open-secret-santa-app</artifactId>

--- a/open-secret-santa-app/src/main/java/com/moac/android/opensecretsanta/activity/AssignmentSharerActivity.java
+++ b/open-secret-santa-app/src/main/java/com/moac/android/opensecretsanta/activity/AssignmentSharerActivity.java
@@ -7,7 +7,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -31,7 +30,6 @@ import com.moac.drawengine.DrawEngineProvider;
 import com.moac.drawengine.DrawFailureException;
 import com.moac.drawengine.InvalidDrawEngineException;
 
-import java.io.IOException;
 import java.util.*;
 
 //import android.content.BroadcastReceiver;

--- a/open-secret-santa-app/src/main/java/com/moac/android/opensecretsanta/database/DatabaseManager.java
+++ b/open-secret-santa-app/src/main/java/com/moac/android/opensecretsanta/database/DatabaseManager.java
@@ -18,6 +18,7 @@ package com.moac.android.opensecretsanta.database;
 
 import android.database.SQLException;
 import com.j256.ormlite.stmt.DeleteBuilder;
+import com.j256.ormlite.stmt.SelectArg;
 import com.moac.android.opensecretsanta.types.*;
 
 import java.util.List;
@@ -126,10 +127,14 @@ public class DatabaseManager {
 
     public Member queryMemberWithNameForGroup(long groupId, String name) {
         try {
+            // Use SelectArg to ensure values are properly escaped
+            // Refer - http://ormlite.com/javadoc/ormlite-core/doc-files/ormlite_3.html#index-select-arguments
+            SelectArg selectArg = new SelectArg();
+            selectArg.setValue(name);
             return mDbHelper.getDaoEx(Member.class).queryBuilder()
               .where().eq(Member.Columns.GROUP_ID_COLUMN, groupId)
               .and()
-              .eq(Member.Columns.NAME_COLUMN, name)
+              .eq(Member.Columns.NAME_COLUMN, selectArg)
               .queryForFirst();
         } catch(java.sql.SQLException e) {
             throw new SQLException(e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.moac.android.opensecretsanta</groupId>
   <artifactId>open-secret-santa-app-parent</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
   <packaging>pom</packaging>
   <name>open-secret-santa-app - Parent</name>
 


### PR DESCRIPTION
Fixes to prevent SQLException when using queryMemberWithNameForGroup as reported in crash reports
